### PR TITLE
adding tirm to names check

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,7 @@ async function generateFrames(csvData: string, framesPerRow: number, gap: number
     for (const [key, value] of Object.entries(row)) {
       if (processedItems % 200 == 0) await delay(40); // quick'n'dirty to make the UI responsive a bit
       console.log("Processing key-value pair:", { key, value });
-      const textLayer = newFrame.findOne(node => node.type === "TEXT" && node.name === key);
+      const textLayer = newFrame.findOne(node => node.type === "TEXT" && node.name.trim() === key.trim());
       if (textLayer) {
         (textLayer as TextNode).characters = value;
       }


### PR DESCRIPTION
I ran across a bug where a `\r` character was appending one of my cell headers and couldn't be matched properly. This PR adds a simple trim function to both the key and the name, removing any white space or invisible characters to the name and the key when comparing. 